### PR TITLE
fix #642 crash when ERROR during registerWithRegistrar

### DIFF
--- a/flutter_sound/ios/Classes/FlutterSoundPlayerManager.mm
+++ b/flutter_sound/ios/Classes/FlutterSoundPlayerManager.mm
@@ -44,7 +44,10 @@ FlutterSoundPlayerManager* flutterSoundPlayerManager = nil; // Singleton
         FlutterMethodChannel* aChannel = [FlutterMethodChannel methodChannelWithName:@"com.dooboolab.flutter_sound_player"
                                         binaryMessenger:[registrar messenger]];
         if (flutterSoundPlayerManager != nil)
+        {
                 NSLog(@"ERROR during registerWithRegistrar: flutterSoundPlayerManager != nil");
+                return;
+        }
         flutterSoundPlayerManager = [[FlutterSoundPlayerManager alloc] init];
         flutterSoundPlayerManager ->channel = aChannel;
         [registrar addMethodCallDelegate: flutterSoundPlayerManager channel: aChannel];


### PR DESCRIPTION
fix #642 crash when "ERROR during registerWithRegistrar: flutterSoundPlayerManager != nil" occurs.

It could be considered as a workaround rather than a fix though.

But at leat I can make flutter_sound coexists with just_audio and so far it seems that my app doesn't crash anymore.

I just added a return statement before we reach the statements that cause the crash.
